### PR TITLE
feat(layout): configurable cell widths

### DIFF
--- a/src/components/content-list.ts
+++ b/src/components/content-list.ts
@@ -37,7 +37,7 @@ export class ContentList extends Content {
   }
 
   protected createLayout(): Layout {
-    return new Layout(this.cardConfig.layout, CardOrientation.VERTICAL);
+    return new Layout(this.cardConfig.layout, CardOrientation.VERTICAL, this.cardConfig.cellWidths);
   }
 
   public disconnectedCallback(): void {

--- a/src/components/content-table.ts
+++ b/src/components/content-table.ts
@@ -101,7 +101,7 @@ export class ContentTable extends Content {
   ];
 
   protected createLayout(): Layout {
-    return new Layout(this.cardConfig.layout, CardOrientation.HORIZONTAL);
+    return new Layout(this.cardConfig.layout, CardOrientation.HORIZONTAL, this.cardConfig.cellWidths);
   }
 
   public renderContent() {

--- a/src/data/layout.ts
+++ b/src/data/layout.ts
@@ -17,10 +17,12 @@ import { CardOrientation, LayoutCell } from "../types";
 export class Layout {
   _layoutCells: Array<string>;
   _cardOrientation: CardOrientation;
+  _cellWidths?: Record<string, string>;
 
-  constructor(cells: Array<LayoutCell | string> | string | undefined, cardOrientation: CardOrientation) {
+  constructor(cells: Array<LayoutCell | string> | string | undefined, cardOrientation: CardOrientation, cellWidths?: Record<string, string>) {
     this._layoutCells = this._parseCardLayout(cells, cardOrientation);
     this._cardOrientation = cardOrientation;
+    this._cellWidths = cellWidths;
   }
 
   /**
@@ -41,7 +43,7 @@ export class Layout {
 
     return this._layoutCells
       .map((cell) => {
-        return layoutValues.get(cell);
+        return this._cellWidths?.[cell] ?? layoutValues.get(cell);
       })
       .join(" ");
   }

--- a/src/editor/departures-card-editor.ts
+++ b/src/editor/departures-card-editor.ts
@@ -10,7 +10,7 @@ import { cardStyles, contentCore } from "../styles";
 import { EntityTab } from "./entity-tab";
 import { mdiTableRow, mdiPalette, mdiFormatListBulleted, mdiAnimation } from "@mdi/js";
 import { AnimatePreset, animatePresets } from "../animate-presets";
-import { DEFAULT_ARRIVAL_OFFSET, DEFAULT_DEPARTURE_ANIMATION, DEFAULT_DEPARTURES_TO_SHOW, DEFAULT_SCROLL_BACK_TIMEOUT } from "../constants";
+import { DEFAULT_ARRIVAL_OFFSET, DEFAULT_DEPARTURE_ANIMATION, DEFAULT_DEPARTURES_TO_SHOW, DEFAULT_SCROLL_BACK_TIMEOUT, LAYOUT_HORIZONTAL, LAYOUT_VERTICAL } from "../constants";
 
 @customElement("departures-card-editor")
 export class DeparturesCardEditor extends LitElement implements LovelaceCardEditor {
@@ -260,7 +260,7 @@ export class DeparturesCardEditor extends LitElement implements LovelaceCardEdit
     },
   ];
 
-  private _schemaLayout = (localize: Function) => [
+  private _schemaLayout = (localize: Function, layout: Array<string>, orientation: CardOrientation) => [
     {
       name: "layout",
       selector: {
@@ -277,6 +277,27 @@ export class DeparturesCardEditor extends LitElement implements LovelaceCardEdit
         },
       },
     },
+    ...(layout.length > 0
+      ? [
+          {
+            type: "constant",
+            name: "cellWidths",
+            required: true,
+          },
+          {
+            name: "cellWidths",
+            type: "grid",
+            schema: layout.map((cell) => {
+              const defaultWidths = orientation === CardOrientation.HORIZONTAL ? LAYOUT_HORIZONTAL : LAYOUT_VERTICAL;
+              return {
+                name: cell,
+                description: { suggested_value: defaultWidths.get(cell) ?? "" },
+                selector: { text: {} },
+              };
+            }),
+          },
+        ]
+      : []),
   ];
 
   private _schemaAnimation = (localize: Function) => [
@@ -378,7 +399,13 @@ export class DeparturesCardEditor extends LitElement implements LovelaceCardEdit
 
     const schemaGeneral = this._schemaGeneral(this._config!.showCardHeader);
     const schemaDesign = this._schemaDesign(this.computeLabelCallback, this._config.cardOrientation, this._config.limitEntities, this._config.entities?.length ?? 1);
-    const schemaLayout = this._schemaLayout(this.computeLabelCallback);
+    const layout = this._config.layout ?? [];
+    const orientation = this._config.cardOrientation;
+    const schemaLayout = this._schemaLayout(this.computeLabelCallback, layout, orientation);
+    const layoutData = {
+      ...this._config,
+      cellWidths: Object.fromEntries(layout.map((cell) => [cell, this._config!.cellWidths?.[cell] ?? ""])),
+    };
     const schemaAnimation = this._schemaAnimation(this.computeLabelCallback);
     const schemaInteractions = this._schemaInteractions();
 
@@ -412,11 +439,16 @@ export class DeparturesCardEditor extends LitElement implements LovelaceCardEdit
         <div style="padding: 16px 0px;">
           <ha-form
             .schema="${schemaLayout}"
-            .data="${this._config}"
+            .data="${layoutData}"
             .hass="${this.hass}"
-            .computeLabel=${this.computeLabelCallback}
+            .computeLabel=${this.computeLabelLayoutCallback}
             .computeHelper=${this.computeHelperCallback}
             @value-changed=${this.configChanged}></ha-form>
+          ${layout.length > 0
+            ? html`<p class="secondary" style="margin: 0 16px 8px; font-size: 12px; color: var(--secondary-text-color);">
+                ${localize("card.editor.help.cellWidths", lang)}
+              </p>`
+            : nothing}
         </div>
         ${this._config?.cardOrientation == CardOrientation.HORIZONTAL
           ? html`<div class="error">
@@ -503,6 +535,13 @@ export class DeparturesCardEditor extends LitElement implements LovelaceCardEdit
 
   private computeLabelCallback = (schema: any) => localize(`card.editor.${schema.name}`, this.hass.locale?.language);
 
+  private computeLabelLayoutCallback = (schema: any) => {
+    const lang = this.hass.locale?.language;
+    const cellLabel = localize(`card.editor.layout-cells.${schema.name}`, lang);
+    if (cellLabel !== `card.editor.layout-cells.${schema.name}`) return cellLabel;
+    return localize(`card.editor.${schema.name}`, lang);
+  };
+
   private computeHelperCallback(schema: any) {
     let help_text = localize(`card.editor.help.${schema.name}`, this.hass.locale?.language);
 
@@ -576,6 +615,11 @@ export class DeparturesCardEditor extends LitElement implements LovelaceCardEdit
     }
 
     const newConfig = { ...(event.detail.value as Config) } as Config;
+
+    if (newConfig.cellWidths) {
+      const cleaned = Object.fromEntries(Object.entries(newConfig.cellWidths).filter(([, v]) => v !== ""));
+      newConfig.cellWidths = Object.keys(cleaned).length > 0 ? cleaned : undefined;
+    }
 
     if (this._config?.departureAnimation != newConfig.departureAnimation) {
       this._cancelPreviewAnimations();

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -30,6 +30,7 @@
         "estimated-time": "Odhadovaný čas",
         "delay": "Zpoždění"
       },
+      "cellWidths": "Šířky buněk (např. 50px, 1fr, auto)",
       "layoutWarning": "Následující buňky budou ignorovány při horizontální orientaci karty",
 
       "animation-expandable": "Ikona a animace odjezdu",
@@ -64,6 +65,7 @@
         "sortDepartures": "Seřadí odjezdy podle plánovaného času",
         "scrollBackTimeout": "Čas v sekundách, po kterém se seznam automaticky vrátí na začátek",
         "layout": "Konfigurace zobrazených buněk a jejich pořadí v řádku odjezdu",
+        "cellWidths": "Řádek odjezdu používá CSS grid layout. Zde lze doladit šířku každé buňky (např. 50px, 1fr, auto). Prázdná hodnota použije výchozí šířku.",
         "departureIcon": "Pokud není zadána vlastní ikona, použije se ikona dopravy z entity",
         "animateLine": "Je-li vypnuto, animuje se pouze buňka s časem odjezdu",
         "arrivalTimeOffset": "Čas v minutách před odjezdem, kdy se spustí animace",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -30,6 +30,7 @@
         "estimated-time": "Geschätzte Zeit",
         "delay": "Verspätung"
       },
+      "cellWidths": "Zellenbreiten (z.B. 50px, 1fr, auto)",
       "layoutWarning": "Die folgenden Zellen werden bei horizontaler Kartenausrichtung ignoriert",
 
       "animation-expandable": "Ankunftssymbol & Animation",
@@ -64,6 +65,7 @@
         "sortDepartures": "Sortiert die Ankünfte nach ihrer geplanten Zeit",
         "scrollBackTimeout": "Zeit in Sekunden, nach der automatisch zum Listenanfang zurückgescrollt wird",
         "layout": "Konfiguration der angezeigten Zellen und ihrer Reihenfolge in einer Ankunftszeile",
+        "cellWidths": "Die Abfahrtszeile verwendet ein CSS-Grid-Layout. Hier kann die Breite jeder Zelle angepasst werden (z.B. 50px, 1fr, auto). Leerer Wert verwendet die Standardbreite.",
         "departureIcon": "Wenn kein benutzerdefiniertes Symbol festgelegt ist, wird das transport icon der Entität für die Animation verwendet",
         "animateLine": "Wenn deaktiviert, wird nur die Zelle 'Ankunft in' animiert",
         "arrivalTimeOffset": "Zeit in Minuten vor der geplanten Ankunft, ab der die Animation startet",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,6 +30,7 @@
         "estimated-time": "Estimated time",
         "delay": "Delay"
       },
+      "cellWidths": "Cell widths (e.g. 50px, 1fr, auto)",
       "layoutWarning": "The following cells will be ignored when using the horizontal orientation",
 
       "animation-expandable": "Departure icon & animation",
@@ -64,6 +65,7 @@
         "sortDepartures": "Sort departures by their planned time",
         "scrollBackTimeout": "Time in seconds before the list automatically scrolls back to the top",
         "layout": "Configure which cells are shown and their order in a departure row",
+        "cellWidths": "The departure row uses a CSS grid layout. Fine-tune the width of each cell here (e.g. 50px, 1fr, auto). Empty value uses the default width.",
         "departureIcon": "If no custom icon is defined, the entity's transport icon will be used for the animation",
         "animateLine": "If disabled, only the departure time cell will be animated",
         "arrivalTimeOffset": "Time in minutes before departure when the animation starts",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -30,6 +30,7 @@
         "estimated-time": "Hora estimada",
         "delay": "Retraso"
       },
+      "cellWidths": "Anchos de celda (p.ej. 50px, 1fr, auto)",
       "layoutWarning": "Las siguientes celdas serán ignoradas con orientación horizontal",
 
       "animation-expandable": "Icono y animación de salida",
@@ -64,6 +65,7 @@
         "sortDepartures": "Ordena las salidas por su hora planificada",
         "scrollBackTimeout": "Tiempo en segundos antes de que la lista vuelva automáticamente al inicio",
         "layout": "Configuración de las celdas mostradas y su orden en una fila de salida",
+        "cellWidths": "La fila de salida utiliza un diseño CSS grid. Aquí se puede ajustar el ancho de cada celda (p.ej. 50px, 1fr, auto). Valor vacío usa el ancho predeterminado.",
         "departureIcon": "Si no se define icono personalizado, se usará el icono de transporte de la entidad",
         "animateLine": "Si está desactivado, solo se animará la celda de tiempo de salida",
         "arrivalTimeOffset": "Tiempo en minutos antes de la salida cuando comienza la animación",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -30,6 +30,7 @@
         "estimated-time": "Heure estimée",
         "delay": "Retard"
       },
+      "cellWidths": "Largeurs des cellules (ex. 50px, 1fr, auto)",
       "layoutWarning": "Les cellules suivantes seront ignorées en orientation horizontale",
 
       "animation-expandable": "Icône et animation de départ",
@@ -64,6 +65,7 @@
         "sortDepartures": "Trie les départs par leur heure planifiée",
         "scrollBackTimeout": "Temps en secondes avant que la liste revienne automatiquement au début",
         "layout": "Configuration des cellules affichées et de leur ordre dans une ligne de départ",
+        "cellWidths": "La ligne de départ utilise une mise en page CSS grid. Affinez ici la largeur de chaque cellule (ex. 50px, 1fr, auto). Valeur vide utilise la largeur par défaut.",
         "departureIcon": "Si aucune icône personnalisée n'est définie, l'icône de transport de l'entité sera utilisée",
         "animateLine": "Si désactivé, seule la cellule d'heure de départ sera animée",
         "arrivalTimeOffset": "Temps en minutes avant le départ à partir duquel l'animation démarre",

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -30,6 +30,7 @@
         "estimated-time": "Prognozētais laiks",
         "delay": "Kavēšanās"
       },
+      "cellWidths": "Šūnu platumi (piem. 50px, 1fr, auto)",
       "layoutWarning": "Šīs šūnas tiks ignorētas horizontālā kartes orientācijā",
 
       "animation-expandable": "Atiešanas ikona un animācija",
@@ -64,6 +65,7 @@
         "sortDepartures": "Kārto atiešanas pēc plānotā laika",
         "scrollBackTimeout": "Laiks sekundēs, pēc kura saraksts automātiski atgriežas sākumā",
         "layout": "Rādāmo šūnu un to secības konfigurācija atiešanas rindā",
+        "cellWidths": "Atiešanas rinda izmanto CSS grid izkārtojumu. Šeit var precizēt katras šūnas platumu (piem. 50px, 1fr, auto). Tukša vērtība izmanto noklusējuma platumu.",
         "departureIcon": "Ja nav norādīta pielāgota ikona, tiks izmantota entītijas transporta ikona",
         "animateLine": "Ja atspējots, tiks animēta tikai atiešanas laika šūna",
         "arrivalTimeOffset": "Laiks minūtēs pirms atiešanas, kad sākas animācija",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -30,6 +30,7 @@
         "estimated-time": "Szacowany czas",
         "delay": "Opóźnienie"
       },
+      "cellWidths": "Szerokości komórek (np. 50px, 1fr, auto)",
       "layoutWarning": "Następujące komórki będą ignorowane przy poziomej orientacji karty",
 
       "animation-expandable": "Ikona i animacja odjazdu",
@@ -64,6 +65,7 @@
         "sortDepartures": "Sortuje odjazdy według planowanego czasu",
         "scrollBackTimeout": "Czas w sekundach, po którym lista automatycznie wraca na początek",
         "layout": "Konfiguracja wyświetlanych komórek i ich kolejności w wierszu odjazdu",
+        "cellWidths": "Wiersz odjazdu używa układu CSS grid. Tutaj można dostosować szerokość każdej komórki (np. 50px, 1fr, auto). Pusta wartość używa domyślnej szerokości.",
         "departureIcon": "Jeśli nie podano własnej ikony, używana jest ikona transportu encji",
         "animateLine": "Gdy wyłączone, animowana jest tylko komórka z czasem odjazdu",
         "arrivalTimeOffset": "Czas w minutach przed odjazdem, od którego startuje animacja",

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface Config extends LovelaceCardConfig {
   entities?: EntityConfig[];
   icon: string;
   layout: Array<LayoutCell | string>;
+  cellWidths?: Record<string, string>;
   scrollBackTimeout: number;
   showCardHeader: boolean;
   showListHeader: boolean;

--- a/tests/data/layout.test.ts
+++ b/tests/data/layout.test.ts
@@ -47,6 +47,17 @@ describe("Layout", () => {
     });
   });
 
+  describe("Custom cellWidths", () => {
+    it("should use custom width for a cell", () => {
+      const l = new Layout([LayoutCell.ICON, LayoutCell.TIME_DIFF], CardOrientation.VERTICAL, { "icon": "200px" });
+      expect(l.getColumns()).toEqual(`200px ${LAYOUT_VERTICAL.get(LayoutCell.TIME_DIFF)}`);
+    });
+    it("should fall back to default width when cellWidths not set for cell", () => {
+      const l = new Layout([LayoutCell.ICON, LayoutCell.TIME_DIFF], CardOrientation.VERTICAL, { "time-diff": "100px" });
+      expect(l.getColumns()).toEqual(`${LAYOUT_VERTICAL.get(LayoutCell.ICON)} 100px`);
+    });
+  });
+
   describe("Default horizontal layout", () => {
     let layout = new Layout(undefined, CardOrientation.HORIZONTAL);
 


### PR DESCRIPTION
## Summary
- Adds optional `cellWidths` config to override the default CSS grid column widths per cell
- Each selected cell in the layout editor gets a text input with the default width as placeholder
- Empty value falls back to the built-in default

## Config example
```yaml
cellWidths:
  destination: 2fr
  time-diff: 80px
```