### PR TITLE
feat(layout): add station-name cell

### DIFF
--- a/src/components/content.ts
+++ b/src/components/content.ts
@@ -163,6 +163,9 @@ export abstract class Content extends LitElement {
 
     layoutCells.forEach((cell) => {
       switch (cell) {
+        case LayoutCell.STATION_NAME:
+          content.push(html`<div class="list-header-icon">${localize("card.list-header.station-name", this.language)}</div>`);
+          break;
         case LayoutCell.ICON:
           content.push(html`<div class="list-header-icon">${localize("card.list-header.icon", this.language)}</div>`);
           break;
@@ -225,6 +228,9 @@ export abstract class Content extends LitElement {
 
     layoutCells.forEach((cell) => {
       switch (cell) {
+        case LayoutCell.STATION_NAME:
+          content.push(this.renderStationName(departure));
+          break;
         case LayoutCell.ICON:
           content.push(this.renderTransportIcon(departure));
           break;
@@ -299,6 +305,17 @@ export abstract class Content extends LitElement {
     this._selectedTripId = departure.time.tripId;
     this._dialogTitle = `${departure.lineName} → ${departure.destinationName}`;
     this._dialogOpen = true;
+  }
+
+  /**
+   * Renders a station name for this entity.
+   * @param departure - The departure data row containing icon information
+   * @returns A template result containing the station name content.
+   */
+  protected renderStationName(departure: DeparturesDataRow): TemplateResult {
+    const station = departure.stationName;
+
+    return html`<div class="cell-station-name" theme=${this.theme}>${station}</div>`;
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_SCROLL_BACK_TIMEOUT = 5;
 export const DEFAULT_CARD_THEME = CardTheme.BASIC;
 
 export const LAYOUT_VERTICAL = new Map<string, string>([
+  [LayoutCell.STATION_NAME, "1fr"],
   [LayoutCell.ICON, "30px"],
   [LayoutCell.LINE, "50px"],
   [LayoutCell.DESTINATION, "1fr"],
@@ -31,6 +32,7 @@ export const LAYOUT_VERTICAL = new Map<string, string>([
   [LayoutCell.DELAY, "45px"],
 ]);
 export const LAYOUT_HORIZONTAL = new Map<string, string>([
+  [LayoutCell.STATION_NAME, "1fr"],
   [LayoutCell.ICON, "30px"],
   [LayoutCell.LINE, "50px"],
   [LayoutCell.DESTINATION, "1fr"],

--- a/src/data/data-pool.ts
+++ b/src/data/data-pool.ts
@@ -65,6 +65,7 @@ export class DepartureTimesPool {
             lineColor: dep.lineColor,
             icon: dep.icon,
             time: time,
+            stationName: dep.stationName,
           });
         }
       });
@@ -131,6 +132,7 @@ export class DepartureTimesPool {
     const lineColor = config.lineColor;
     const times = parser.getTimes();
     const icon = config.icon || parser.getTransportIcon() || DEFAULT_ENTITY_ICON;
+    const stationName = config.stationName ?? "";
 
     if (!this._data.has(config.entity)) {
       // create a new data entry
@@ -141,6 +143,7 @@ export class DepartureTimesPool {
         lineColor: lineColor,
         icon: icon,
         times: times,
+        stationName: stationName,
       });
 
       console.debug("Create new data for entity", config.entity);
@@ -154,6 +157,7 @@ export class DepartureTimesPool {
         data.lineColor = lineColor;
         data.icon = icon;
         data.times = times;
+        data.stationName = stationName;
 
         console.debug("Update data for entity", config.entity);
       }

--- a/src/editor/departures-card-editor.ts
+++ b/src/editor/departures-card-editor.ts
@@ -268,11 +268,18 @@ export class DeparturesCardEditor extends LitElement implements LovelaceCardEdit
           reorder: true,
           multiple: true,
           custom_value: false,
-          options: [LayoutCell.ICON, LayoutCell.LINE, LayoutCell.DESTINATION, LayoutCell.PLANNED_TIME, LayoutCell.ESTIMATED_TIME, LayoutCell.TIME_DIFF, LayoutCell.DELAY].map(
-            (cellName) => {
-              return { value: cellName, label: localize({ name: `layout-cells.${cellName}` }) };
-            },
-          ),
+          options: [
+            LayoutCell.STATION_NAME,
+            LayoutCell.ICON,
+            LayoutCell.LINE,
+            LayoutCell.DESTINATION,
+            LayoutCell.PLANNED_TIME,
+            LayoutCell.ESTIMATED_TIME,
+            LayoutCell.TIME_DIFF,
+            LayoutCell.DELAY,
+          ].map((cellName) => {
+            return { value: cellName, label: localize({ name: `layout-cells.${cellName}` }) };
+          }),
           default: [LayoutCell.ICON, LayoutCell.DESTINATION],
         },
       },

--- a/src/editor/departures-entity-editor.ts
+++ b/src/editor/departures-entity-editor.ts
@@ -39,6 +39,10 @@ export class DeparturesCardEntityEditor extends LitElement {
       selector: { entity: {}, domain: "ha_departures" },
     },
     {
+      name: "stationName",
+      selector: { text: {} },
+    },
+    {
       name: "destinationName",
       selector: { text: {} },
     },

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -4,7 +4,6 @@
       "title": "Nadpis karty (volitelné)",
       "icon": "Ikona karty (volitelné)",
       "showCardHeader": "Zobrazit záhlaví karty",
-
       "design-expandable": "Design a obsah",
       "cardOrientation": "Orientace karty",
       "cardOrientationVerticalDescription": "Zobrazí odjezdy v rolovatelném seznamu",
@@ -18,7 +17,6 @@
       "entitiesFilter": "Filtr odjezdů (minuty)",
       "scrollBackTimeout": "Čas návratu (sekundy)",
       "sortDepartures": "Seřadit entity podle plánovaného odjezdu",
-
       "layout-expandable": "Rozvržení řádku odjezdu",
       "layout": "Přidat buňku",
       "layout-cells": {
@@ -28,10 +26,10 @@
         "time-diff": "Odjezd za",
         "planned-time": "Plánovaný čas",
         "estimated-time": "Odhadovaný čas",
+        "station-name": "Název stanice",
         "delay": "Zpoždění"
       },
       "layoutWarning": "Následující buňky budou ignorovány při horizontální orientaci karty",
-
       "animation-expandable": "Ikona a animace odjezdu",
       "departureIcon": "Vlastní ikona odjezdu",
       "animateLine": "Animovat řádek odjezdu",
@@ -39,19 +37,16 @@
       "departureAnimation": "Animace odjezdu",
       "departureAnimationDuration": "Doba animace (ms)",
       "noAnimation": "Žádná",
-
       "interactions-expandable": "Interakce",
-
       "entities-expandable": "Entity (povinné)",
       "addEntity": "Přidat entitu",
-
       "card.editor.interactions-expandable": "Interakce",
       "tap_action": "Akce při klepnutí",
       "hold_action": "Akce při podržení",
       "double_tap_action": "Akce při dvojitém klepnutí",
-
       "entity": {
         "entity": "Entita",
+        "stationName": "Název stanice",
         "destinationName": "Název cíle",
         "lineName": "Název linky",
         "lineColor": "Barva linky",
@@ -72,6 +67,7 @@
       }
     },
     "list-header": {
+      "station-name": "Stanice",
       "icon": "Ikona",
       "line": "Linka",
       "destination": "Cíl",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -4,7 +4,6 @@
       "title": "Kartenüberschrift (optional)",
       "icon": "Kartensymbol  (optional)",
       "showCardHeader": "Kartenüberschrift anzeigen",
-
       "design-expandable": "Design & Inhalt",
       "cardOrientation": "Kartenausrichtung",
       "cardOrientationVerticalDescription": "Zeigt die Ankünfte in einer scrollbaren Liste",
@@ -18,7 +17,6 @@
       "entitiesFilter": "Abfahrtsfilter (Minuten)",
       "scrollBackTimeout": "Zurückscroll-Zeit (Sekunden)",
       "sortDepartures": "Entitäten nach geplanter Ankunft sortieren",
-
       "layout-expandable": "Layout der Ankunftszeile",
       "layout": "Zelle hinzufügen",
       "layout-cells": {
@@ -28,10 +26,10 @@
         "time-diff": "Ankunft in",
         "planned-time": "Geplante Zeit",
         "estimated-time": "Geschätzte Zeit",
+        "station-name": "Stationsname",
         "delay": "Verspätung"
       },
       "layoutWarning": "Die folgenden Zellen werden bei horizontaler Kartenausrichtung ignoriert",
-
       "animation-expandable": "Ankunftssymbol & Animation",
       "departureIcon": "Benutzerdefiniertes Ankunftssymbol",
       "animateLine": "Ankunftszeile animieren",
@@ -39,19 +37,16 @@
       "departureAnimation": "Ankunftsanimation",
       "departureAnimationDuration": "Animationsdauer (ms)",
       "noAnimation": "Keine",
-
       "interactions-expandable": "Interaktionen",
-
       "entities-expandable": "Entitäten (erforderlich)",
       "addEntity": "Entität hinzufügen",
-
       "card.editor.interactions-expandable": "Interaktionen",
       "tap_action": "Verhalten bei Antippen",
       "hold_action": "Verhalten bei Festhalten",
       "double_tap_action": "Verhalten bei Doppeltipp",
-
       "entity": {
         "entity": "Entität",
+        "stationName": "Stationsname",
         "destinationName": "Zielname",
         "lineName": "Linienname",
         "lineColor": "Linienfarbe",
@@ -72,6 +67,7 @@
       }
     },
     "list-header": {
+      "station-name": "Station",
       "icon": "Icon",
       "line": "Linie",
       "destination": "Ziel",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,6 @@
       "title": "Card header text (optional)",
       "icon": "Card icon (optional)",
       "showCardHeader": "Show card header",
-
       "design-expandable": "Design & content",
       "cardOrientation": "Card orientation",
       "cardOrientationVerticalDescription": "Show departures in a scrollable list",
@@ -18,7 +17,6 @@
       "entitiesFilter": "Departure filter (minutes)",
       "scrollBackTimeout": "Scroll-back time (seconds)",
       "sortDepartures": "Sort entities by planned departure time",
-
       "layout-expandable": "Departure layout",
       "layout": "Add cell",
       "layout-cells": {
@@ -28,10 +26,10 @@
         "time-diff": "Departure in",
         "planned-time": "Planned time",
         "estimated-time": "Estimated time",
+        "station-name": "Station name",
         "delay": "Delay"
       },
       "layoutWarning": "The following cells will be ignored when using the horizontal orientation",
-
       "animation-expandable": "Departure icon & animation",
       "departureIcon": "Custom departure icon",
       "animateLine": "Animate departure line",
@@ -39,19 +37,16 @@
       "departureAnimation": "Departure animation",
       "departureAnimationDuration": "Animation duration (ms)",
       "noAnimation": "None",
-
       "interactions-expandable": "Interactions",
-
       "entities-expandable": "Entities (required)",
       "addEntity": "Add entity",
-
       "card.editor.interactions-expandable": "Interactions",
       "tap_action": "Tap action",
       "hold_action": "Hold action",
       "double_tap_action": "Double tap action",
-
       "entity": {
         "entity": "Entity",
+        "stationName": "Station name",
         "destinationName": "Destination name",
         "lineName": "Line name",
         "lineColor": "Line color",
@@ -72,6 +67,7 @@
       }
     },
     "list-header": {
+      "station-name": "Station",
       "icon": "Icon",
       "line": "Line",
       "destination": "Destination",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -4,7 +4,6 @@
       "title": "Título de la tarjeta (opcional)",
       "icon": "Icono de la tarjeta (opcional)",
       "showCardHeader": "Mostrar encabezado de tarjeta",
-
       "design-expandable": "Diseño y contenido",
       "cardOrientation": "Orientación de la tarjeta",
       "cardOrientationVerticalDescription": "Muestra las salidas en una lista desplazable",
@@ -18,7 +17,6 @@
       "entitiesFilter": "Filtro de salidas (minutos)",
       "scrollBackTimeout": "Tiempo de retorno (segundos)",
       "sortDepartures": "Ordenar entidades por hora de salida planificada",
-
       "layout-expandable": "Diseño de fila de salida",
       "layout": "Añadir celda",
       "layout-cells": {
@@ -28,10 +26,10 @@
         "time-diff": "Sale en",
         "planned-time": "Hora planificada",
         "estimated-time": "Hora estimada",
+        "station-name": "Nombre de la estación",
         "delay": "Retraso"
       },
       "layoutWarning": "Las siguientes celdas serán ignoradas con orientación horizontal",
-
       "animation-expandable": "Icono y animación de salida",
       "departureIcon": "Icono de salida personalizado",
       "animateLine": "Animar fila de salida",
@@ -39,19 +37,16 @@
       "departureAnimation": "Animación de salida",
       "departureAnimationDuration": "Duración de animación (ms)",
       "noAnimation": "Ninguna",
-
       "interactions-expandable": "Interacciones",
-
       "entities-expandable": "Entidades (requerido)",
       "addEntity": "Añadir entidad",
-
       "card.editor.interactions-expandable": "Interacciones",
       "tap_action": "Acción al tocar",
       "hold_action": "Acción al mantener",
       "double_tap_action": "Acción al doble toque",
-
       "entity": {
         "entity": "Entidad",
+        "stationName": "Nombre de la estación",
         "destinationName": "Nombre del destino",
         "lineName": "Nombre de línea",
         "lineColor": "Color de línea",
@@ -72,6 +67,7 @@
       }
     },
     "list-header": {
+      "station-name": "Estación",
       "icon": "Icono",
       "line": "Línea",
       "destination": "Destino",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -4,7 +4,6 @@
       "title": "Titre de la carte (optionnel)",
       "icon": "Icône de la carte (optionnel)",
       "showCardHeader": "Afficher l'en-tête de la carte",
-
       "design-expandable": "Design et contenu",
       "cardOrientation": "Orientation de la carte",
       "cardOrientationVerticalDescription": "Affiche les départs dans une liste défilante",
@@ -18,7 +17,6 @@
       "entitiesFilter": "Filtre de départs (minutes)",
       "scrollBackTimeout": "Délai de retour (secondes)",
       "sortDepartures": "Trier les entités par heure de départ planifiée",
-
       "layout-expandable": "Mise en page de la ligne de départ",
       "layout": "Ajouter une cellule",
       "layout-cells": {
@@ -28,10 +26,10 @@
         "time-diff": "Départ dans",
         "planned-time": "Heure planifiée",
         "estimated-time": "Heure estimée",
+        "station-name": "Nom de la station",
         "delay": "Retard"
       },
       "layoutWarning": "Les cellules suivantes seront ignorées en orientation horizontale",
-
       "animation-expandable": "Icône et animation de départ",
       "departureIcon": "Icône de départ personnalisée",
       "animateLine": "Animer la ligne de départ",
@@ -39,19 +37,16 @@
       "departureAnimation": "Animation de départ",
       "departureAnimationDuration": "Durée de l'animation (ms)",
       "noAnimation": "Aucune",
-
       "interactions-expandable": "Interactions",
-
       "entities-expandable": "Entités (requis)",
       "addEntity": "Ajouter une entité",
-
       "card.editor.interactions-expandable": "Interactions",
       "tap_action": "Action au toucher",
       "hold_action": "Action au maintien",
       "double_tap_action": "Action au double toucher",
-
       "entity": {
         "entity": "Entité",
+        "stationName": "Nom de la station",
         "destinationName": "Nom de la destination",
         "lineName": "Nom de la ligne",
         "lineColor": "Couleur de la ligne",
@@ -72,6 +67,7 @@
       }
     },
     "list-header": {
+      "station-name": "Station",
       "icon": "Icône",
       "line": "Ligne",
       "destination": "Destination",

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -4,7 +4,6 @@
       "title": "Kartes virsraksts (neobligāts)",
       "icon": "Kartes ikona (neobligāts)",
       "showCardHeader": "Rādīt kartes galveni",
-
       "design-expandable": "Dizains un saturs",
       "cardOrientation": "Kartes orientācija",
       "cardOrientationVerticalDescription": "Rāda atiešanas ritināmā sarakstā",
@@ -18,7 +17,6 @@
       "entitiesFilter": "Atiešanas filtrs (minūtes)",
       "scrollBackTimeout": "Atgriešanās laiks (sekundes)",
       "sortDepartures": "Kārtot entītijas pēc plānotā atiešanas laika",
-
       "layout-expandable": "Atiešanas rindas izkārtojums",
       "layout": "Pievienot šūnu",
       "layout-cells": {
@@ -28,10 +26,10 @@
         "time-diff": "Atiet pēc",
         "planned-time": "Plānotais laiks",
         "estimated-time": "Prognozētais laiks",
+        "station-name": "Stacijas nosaukums",
         "delay": "Kavēšanās"
       },
       "layoutWarning": "Šīs šūnas tiks ignorētas horizontālā kartes orientācijā",
-
       "animation-expandable": "Atiešanas ikona un animācija",
       "departureIcon": "Pielāgota atiešanas ikona",
       "animateLine": "Animēt atiešanas rindu",
@@ -39,19 +37,16 @@
       "departureAnimation": "Atiešanas animācija",
       "departureAnimationDuration": "Animācijas ilgums (ms)",
       "noAnimation": "Nav",
-
       "interactions-expandable": "Mijiedarbības",
-
       "entities-expandable": "Entītijas (nepieciešams)",
       "addEntity": "Pievienot entītiju",
-
       "card.editor.interactions-expandable": "Mijiedarbības",
       "tap_action": "Darbība pieskaroties",
       "hold_action": "Darbība turot",
       "double_tap_action": "Darbība divreiz pieskaroties",
-
       "entity": {
         "entity": "Entītija",
+        "stationName": "Stacijas nosaukums",
         "destinationName": "Galamērķa nosaukums",
         "lineName": "Līnijas nosaukums",
         "lineColor": "Līnijas krāsa",
@@ -72,6 +67,7 @@
       }
     },
     "list-header": {
+      "station-name": "Stacija",
       "icon": "Ikona",
       "line": "Līnija",
       "destination": "Galamērķis",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -4,7 +4,6 @@
       "title": "Nagłówek karty (opcjonalne)",
       "icon": "Ikona karty (opcjonalne)",
       "showCardHeader": "Pokaż nagłówek karty",
-
       "design-expandable": "Wygląd i zawartość",
       "cardOrientation": "Orientacja karty",
       "cardOrientationVerticalDescription": "Wyświetla odjazdy na przewijalnej liście",
@@ -18,7 +17,6 @@
       "entitiesFilter": "Filtr odjazdów (minuty)",
       "scrollBackTimeout": "Czas powrotu (sekundy)",
       "sortDepartures": "Sortuj encje według planowanego odjazdu",
-
       "layout-expandable": "Układ wiersza odjazdu",
       "layout": "Dodaj komórkę",
       "layout-cells": {
@@ -28,10 +26,10 @@
         "time-diff": "Odjazd za",
         "planned-time": "Planowy czas",
         "estimated-time": "Szacowany czas",
+        "station-name": "Nazwa stacji",
         "delay": "Opóźnienie"
       },
       "layoutWarning": "Następujące komórki będą ignorowane przy poziomej orientacji karty",
-
       "animation-expandable": "Ikona i animacja odjazdu",
       "departureIcon": "Własna ikona odjazdu",
       "animateLine": "Animuj wiersz odjazdu",
@@ -39,19 +37,16 @@
       "departureAnimation": "Animacja odjazdu",
       "departureAnimationDuration": "Czas trwania animacji (ms)",
       "noAnimation": "Brak",
-
       "interactions-expandable": "Interakcje",
-
       "entities-expandable": "Encje (wymagane)",
       "addEntity": "Dodaj encję",
-
       "card.editor.interactions-expandable": "Interakcje",
       "tap_action": "Akcja przy dotknięciu",
       "hold_action": "Akcja przy przytrzymaniu",
       "double_tap_action": "Akcja przy podwójnym dotknięciu",
-
       "entity": {
         "entity": "Encja",
+        "stationName": "Nazwa stacji",
         "destinationName": "Nazwa celu",
         "lineName": "Nazwa linii",
         "lineColor": "Kolor linii",
@@ -72,6 +67,7 @@
       }
     },
     "list-header": {
+      "station-name": "Stacja",
       "icon": "Ikona",
       "line": "Linia",
       "destination": "Cel",

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -91,6 +91,9 @@ export const contentCore = css`
     text-align: center;
     border-radius: 1000px;
   }
+  .cell-station-name {
+    text-align: center;
+  }
   .cell-delay {
     color: white;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface EntityConfig {
   icon: string | null;
   lineColor: string | null;
   lineName: string | null;
+  stationName: string;
 }
 
 export type DeparturesData = EntityConfig & {
@@ -73,6 +74,7 @@ export enum LayoutCell {
   LINE = "line",
   PLANNED_TIME = "planned-time",
   TIME_DIFF = "time-diff",
+  STATION_NAME = "station-name",
 }
 
 export interface Alert {

--- a/tests/data/layout.test.ts
+++ b/tests/data/layout.test.ts
@@ -24,6 +24,18 @@ describe("Layout", () => {
     });
   });
 
+  describe("Valid input / horizontal / station-name", () => {
+    const layout = new Layout([LayoutCell.STATION_NAME, LayoutCell.DESTINATION], CardOrientation.HORIZONTAL);
+
+    it("should get cells for station-name and destination", () => {
+      expect(layout.getCells()).toEqual(["station-name", "destination"]);
+    });
+    it("should get columns for station-name and destination", () => {
+      const expectedColumns = `${LAYOUT_HORIZONTAL.get(LayoutCell.STATION_NAME)} ${LAYOUT_HORIZONTAL.get(LayoutCell.DESTINATION)}`;
+      expect(layout.getColumns()).toEqual(expectedColumns);
+    });
+  });
+
   describe("Filter invalid cells", () => {
     let layout = new Layout("icon invalid_1 hello world", CardOrientation.HORIZONTAL);
 
@@ -44,6 +56,16 @@ describe("Layout", () => {
     });
     it("should get default columns if no layout provided", () => {
       expect(layout.getColumns()).toEqual(Array.from(LAYOUT_VERTICAL.values()).join(" "));
+    });
+
+    it("should include station-name cell in vertical layout", () => {
+      const l = new Layout([LayoutCell.STATION_NAME, LayoutCell.TIME_DIFF], CardOrientation.VERTICAL);
+      expect(l.getCells()).toEqual(["station-name", "time-diff"]);
+    });
+    it("should get columns for station-name in vertical layout", () => {
+      const l = new Layout([LayoutCell.STATION_NAME, LayoutCell.TIME_DIFF], CardOrientation.VERTICAL);
+      const expectedColumns = `${LAYOUT_VERTICAL.get(LayoutCell.STATION_NAME)} ${LAYOUT_VERTICAL.get(LayoutCell.TIME_DIFF)}`;
+      expect(l.getColumns()).toEqual(expectedColumns);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds new `station-name` layout cell to display the station/stop name in the departure row
- New `stationName` field in entity config (optional, default `""`)
- Translations for all 7 supported locales