### PR TITLE
fix(station-name): prevent cell overflow and grid misalignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/alex-jung/ha-departures-card",
   "license": "MIT",
   "author": "Alex Jung <jungdevelop@googlemail.com>",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "type": "module",
   "scripts": {
     "start": "rollup -c --watch",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { CardOrientation, CardTheme, LayoutCell } from "./types";
 
-export const CARD_VERSION = "3.8.0";
+export const CARD_VERSION = "3.8.1";
 export const CARD_REPO_URL = "https://github.com/alex-jung/ha-departures-card";
 
 export const DEFAULT_UPDATE_INTERVAL = 10000; // -> 10 sec

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -93,6 +93,9 @@ export const contentCore = css`
   }
   .cell-station-name {
     text-align: center;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
   .cell-delay {
     color: white;


### PR DESCRIPTION
## Summary
- Long station names no longer wrap and cause double-height rows
- Station name length no longer shifts column alignments for other cells

## Root cause
`.cell-station-name` was missing `min-width: 0`. In CSS grid, items default to `min-width: auto`, so the cell expanded to fit its content instead of truncating — breaking both row height and column alignment.