### PR TITLE
feat(entity): add destinationSource option (direction / head_sign / custom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,13 +527,14 @@ title: Frankenstr.
 
 ## Entity Properties
 
-| yaml attribute                      | Type   | Required | Default value |
-| ----------------------------------- | ------ | -------- | ------------- |
-| [linecolor](#linecolor)             | string | no       | empty         |
-| [linename](#linename)               | string | no       | empty         |
-| [destinationname](#destinationname) | string | no       | empty         |
-| [stationName](#stationName)         | string | no       | empty         |
-| [icon](#icon-1)                     | string | no       | empty         |
+| yaml attribute                              | Type   | Required | Default value |
+| ------------------------------------------- | ------ | -------- | ------------- |
+| [linecolor](#linecolor)                     | string | no       | empty         |
+| [linename](#linename)                       | string | no       | empty         |
+| [destinationSource](#destinationsource)     | string | no       | `direction`   |
+| [destinationname](#destinationname)         | string | no       | empty         |
+| [stationName](#stationName)                 | string | no       | empty         |
+| [icon](#icon-1)                             | string | no       | empty         |
 
 ### "lineColor"
 
@@ -571,12 +572,34 @@ entities:
 | ------------------------------------------- | ------------------------------------------ |
 | ![card](assets/image_linecolor_defined.png) | ![card](assets/image_linename_defined.png) |
 
+### "destinationSource"
+
+**Type:** `string`
+**Default**: `"direction"`
+
+Controls which value is used as the destination name for each departure.
+
+| Value       | Description                                                                                   |
+| ----------- | --------------------------------------------------------------------------------------------- |
+| `direction` | Uses the `direction` attribute of the sensor entity (default)                                 |
+| `head_sign` | Uses the `head_sign` field from each individual trip in the `times` array                     |
+| `custom`    | Uses the manually defined [`destinationName`](#destinationname) value                         |
+
+The `head_sign` mode is useful when a single entity contains trips with different final destinations — for example during disruptions when trains are rerouted to an alternative terminal. Each departure row will then show the actual destination of that specific trip instead of the entity's fixed direction attribute.
+
+```yaml
+type: custom:departures-card
+entities:
+  - entity: sensor.karlsfeld_s2_ostbahnhof
+    destinationSource: head_sign
+```
+
 ### "destinationName"
 
 **Type:** `string`
 **Default**: `""`
 
-Option to overwrite default destination name provided by API.
+Option to overwrite default destination name provided by API. Only used when [`destinationSource`](#destinationsource) is set to `custom`.
 
 ```yaml
 type: custom:departures-card

--- a/dev/ha-config/configuration.yaml
+++ b/dev/ha-config/configuration.yaml
@@ -27,11 +27,11 @@ template:
           icon: mdi:tram
           times: >
             {{ [
-              {"planned": (now() + timedelta(minutes=3)).isoformat(),  "estimated": (now() + timedelta(minutes=5)).isoformat(),  "trip_id": "20260316_14:43_de-DELFI_3118795864", "cancelled": false, "head_sign": "Doku-Zentrum", "alerts": true},
-              {"planned": (now() + timedelta(minutes=13)).isoformat(), "estimated": (now() + timedelta(minutes=13)).isoformat(), "trip_id": "20260316_14:53_de-DELFI_3118795863", "cancelled": false, "head_sign": "Doku-Zentrum", "alerts": true},
-              {"planned": (now() + timedelta(minutes=23)).isoformat(), "estimated": (now() + timedelta(minutes=23)).isoformat(), "trip_id": "20260316_15:03_de-DELFI_3118795862", "cancelled": false, "head_sign": "Doku-Zentrum", "alerts": false},
-              {"planned": (now() + timedelta(minutes=33)).isoformat(), "estimated": (now() + timedelta(minutes=33)).isoformat(), "trip_id": "20260316_15:13_de-DELFI_3118795795", "cancelled": false, "head_sign": "Doku-Zentrum", "alerts": false},
-              {"planned": (now() + timedelta(minutes=43)).isoformat(), "estimated": (now() + timedelta(minutes=43)).isoformat(), "trip_id": "20260316_15:23_de-DELFI_3118795860", "cancelled": true,  "head_sign": "Doku-Zentrum", "alerts": false}
+              {"planned": (now() + timedelta(minutes=3)).isoformat(),  "estimated": (now() + timedelta(minutes=5)).isoformat(),  "trip_id": "20260316_14:43_de-DELFI_3118795864", "cancelled": false, "head_sign": "Param-taram", "alerts": true},
+              {"planned": (now() + timedelta(minutes=13)).isoformat(), "estimated": (now() + timedelta(minutes=13)).isoformat(), "trip_id": "20260316_14:53_de-DELFI_3118795863", "cancelled": false, "head_sign": "Param-taram", "alerts": true},
+              {"planned": (now() + timedelta(minutes=23)).isoformat(), "estimated": (now() + timedelta(minutes=23)).isoformat(), "trip_id": "20260316_15:03_de-DELFI_3118795862", "cancelled": false, "head_sign": "Param-taram", "alerts": false},
+              {"planned": (now() + timedelta(minutes=33)).isoformat(), "estimated": (now() + timedelta(minutes=33)).isoformat(), "trip_id": "20260316_15:13_de-DELFI_3118795795", "cancelled": false, "head_sign": "Param-taram", "alerts": false},
+              {"planned": (now() + timedelta(minutes=43)).isoformat(), "estimated": (now() + timedelta(minutes=43)).isoformat(), "trip_id": "20260316_15:23_de-DELFI_3118795860", "cancelled": true,  "head_sign": "Param-taram", "alerts": false}
             ] }}
 
       - name: "U6 Garching Forschungszentrum"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/alex-jung/ha-departures-card",
   "license": "MIT",
   "author": "Alex Jung <jungdevelop@googlemail.com>",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "type": "module",
   "scripts": {
     "start": "rollup -c --watch",

--- a/src/components/content.ts
+++ b/src/components/content.ts
@@ -2,7 +2,7 @@ import { html, LitElement, nothing, TemplateResult, CSSResultGroup, PropertyValu
 import { property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { CardTheme, Config, DeparturesDataRow, LayoutCell } from "../types";
+import { CardTheme, Config, DeparturesDataRow, DestinationSource, LayoutCell } from "../types";
 import { lightFormat } from "date-fns";
 import { contentCore } from "../styles";
 import { DEFAULT_ENTITY_ICON } from "../constants";
@@ -374,9 +374,13 @@ export abstract class Content extends LitElement {
     }
 
     const hasAlerts = departure.time.hasAlerts;
+    const destinationName =
+      departure.destinationSource === DestinationSource.HEAD_SIGN
+        ? (departure.time.headSign ?? departure.destinationName)
+        : departure.destinationName;
 
     return html` <div class="cell-destination" theme=${this.theme}>
-      <span class="cell-destination-label" style=${styleMap(styles)}>${departure.destinationName}</span>
+      <span class="cell-destination-label" style=${styleMap(styles)}>${destinationName}</span>
       ${hasAlerts
         ? html`
             <span class="cell-alert-badge">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { CardOrientation, CardTheme, LayoutCell } from "./types";
 
-export const CARD_VERSION = "3.8.1";
+export const CARD_VERSION = "3.9.0";
 export const CARD_REPO_URL = "https://github.com/alex-jung/ha-departures-card";
 
 export const DEFAULT_UPDATE_INTERVAL = 10000; // -> 10 sec

--- a/src/data/data-pool.ts
+++ b/src/data/data-pool.ts
@@ -1,5 +1,5 @@
 import { HomeAssistant } from "custom-card-helpers";
-import { EntityConfig, DeparturesDataRow, DeparturesData } from "../types";
+import { EntityConfig, DeparturesDataRow, DeparturesData, DestinationSource } from "../types";
 import { DataParser, Parser } from "./data-parsers";
 import { HassEntity } from "home-assistant-js-websocket";
 import { EntityNotAvailable, UnsupportedEntityError } from "../exceptions";
@@ -59,13 +59,8 @@ export class DepartureTimesPool {
       dep.times.forEach((time) => {
         if (time.timeDiff >= 0) {
           list.push({
-            entity: dep.entity,
-            lineName: dep.lineName,
-            destinationName: dep.destinationName,
-            lineColor: dep.lineColor,
-            icon: dep.icon,
+            ...dep,
             time: time,
-            stationName: dep.stationName,
           });
         }
       });
@@ -128,11 +123,25 @@ export class DepartureTimesPool {
   private _createOrUpdateEntry(config: EntityConfig, parser: Parser) {
     const entityId = config.entity;
     const lineName = config.lineName || parser.getLineName();
-    const direction = config.destinationName || parser.getDirection();
     const lineColor = config.lineColor;
     const times = parser.getTimes();
     const icon = config.icon || parser.getTransportIcon() || DEFAULT_ENTITY_ICON;
     const stationName = config.stationName ?? "";
+    const destinationSource = config.destinationSource ?? DestinationSource.DIRECTION;
+
+    let direction: string | null;
+    switch (destinationSource) {
+      case DestinationSource.CUSTOM:
+        direction = config.destinationName;
+        break;
+      case DestinationSource.HEAD_SIGN:
+        direction = null;
+        break;
+      case DestinationSource.DIRECTION:
+      default:
+        direction = parser.getDirection();
+        break;
+    }
 
     if (!this._data.has(config.entity)) {
       // create a new data entry
@@ -140,6 +149,7 @@ export class DepartureTimesPool {
         entity: entityId,
         lineName: lineName,
         destinationName: direction,
+        destinationSource: destinationSource,
         lineColor: lineColor,
         icon: icon,
         times: times,
@@ -154,6 +164,7 @@ export class DepartureTimesPool {
       if (data) {
         data.lineName = lineName;
         data.destinationName = direction;
+        data.destinationSource = destinationSource;
         data.lineColor = lineColor;
         data.icon = icon;
         data.times = times;

--- a/src/editor/departures-entity-editor.ts
+++ b/src/editor/departures-entity-editor.ts
@@ -5,6 +5,7 @@ import { localize } from "../locales/localize";
 import { mdiDelete } from "@mdi/js";
 import { cardStyles } from "../styles";
 import { EntityTab } from "./entity-tab";
+import { DestinationSource } from "../types";
 
 @customElement("departures-entity-editor")
 export class DeparturesCardEntityEditor extends LitElement {
@@ -33,38 +34,60 @@ export class DeparturesCardEntityEditor extends LitElement {
   @property({ attribute: false })
   public data!: EntityTab;
 
-  private _schema = [
-    {
-      name: "entity",
-      selector: { entity: {}, domain: "ha_departures" },
-    },
-    {
-      name: "stationName",
-      selector: { text: {} },
-    },
-    {
-      name: "destinationName",
-      selector: { text: {} },
-    },
-    {
-      name: "",
-      type: "grid",
-      schema: [
-        {
-          name: "lineName",
-          selector: { text: {} },
+  private get _schema() {
+    const lang = this.hass?.locale?.language;
+    const destinationSource = this.data?.config?.destinationSource ?? DestinationSource.DIRECTION;
+
+    return [
+      {
+        name: "entity",
+        selector: { entity: {}, domain: "ha_departures" },
+      },
+      {
+        name: "stationName",
+        selector: { text: {} },
+      },
+      {
+        name: "destinationSource",
+        selector: {
+          select: {
+            mode: "dropdown",
+            options: [
+              { value: DestinationSource.DIRECTION, label: localize("card.editor.destinationSourceOptions.direction", lang) },
+              { value: DestinationSource.HEAD_SIGN, label: localize("card.editor.destinationSourceOptions.head_sign", lang) },
+              { value: DestinationSource.CUSTOM, label: localize("card.editor.destinationSourceOptions.custom", lang) },
+            ],
+          },
         },
-        {
-          name: "lineColor",
-          selector: { text: {} },
-        },
-      ],
-    },
-    {
-      name: "icon",
-      selector: { icon: {} },
-    },
-  ] as const;
+      },
+      ...(destinationSource === DestinationSource.CUSTOM
+        ? [
+            {
+              name: "destinationName",
+              selector: { text: {} },
+            },
+          ]
+        : []),
+      {
+        name: "",
+        type: "grid",
+        schema: [
+          {
+            name: "lineName",
+            selector: { text: {} },
+          },
+          {
+            name: "lineColor",
+            selector: { text: {} },
+          },
+        ],
+      },
+      {
+        name: "icon",
+        selector: { icon: {} },
+      },
+    ] as const;
+  }
 
   protected render() {
     if (!this.hass) {

--- a/src/editor/entity-tab.ts
+++ b/src/editor/entity-tab.ts
@@ -1,4 +1,4 @@
-import { EntityConfig } from "../types";
+import { EntityConfig, DestinationSource } from "../types";
 
 export class EntityTab {
   index: number;
@@ -13,6 +13,7 @@ export class EntityTab {
         lineColor: null,
         lineName: null,
         destinationName: null,
+        destinationSource: DestinationSource.DIRECTION,
       } as EntityConfig;
     } else {
       this.config = config;

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -48,11 +48,17 @@
       "entity": {
         "entity": "Entita",
         "stationName": "Název stanice",
-        "destinationName": "Název cíle",
+        "destinationSource": "Zdroj názvu cíle",
+        "destinationName": "Vlastní název cíle",
         "lineName": "Název linky",
         "lineColor": "Barva linky",
         "icon": "Vlastní ikona dopravy",
         "remove": "Odstranit"
+      },
+      "destinationSourceOptions": {
+        "direction": "Atribut 'direction'",
+        "head_sign": "Atribut 'head_sign'",
+        "custom": "Vlastní hodnota"
       },
       "help": {
         "showListHeader": "Zobrazí záhlaví sloupců seznamu odjezdů",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -48,11 +48,17 @@
       "entity": {
         "entity": "Entität",
         "stationName": "Stationsname",
-        "destinationName": "Zielname",
+        "destinationSource": "Zielname Quelle",
+        "destinationName": "Benutzerdefinierter Zielname",
         "lineName": "Linienname",
         "lineColor": "Linienfarbe",
         "icon": "Transport Icon",
         "remove": "Entfernen"
+      },
+      "destinationSourceOptions": {
+        "direction": "Attribut 'direction'",
+        "head_sign": "Attribut 'head_sign'",
+        "custom": "Benutzerdefiniert"
       },
       "help": {
         "showListHeader": "Zeigt die Spaltenüberschriften der Ankunftsliste an",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -48,11 +48,17 @@
       "entity": {
         "entity": "Entity",
         "stationName": "Station name",
-        "destinationName": "Destination name",
+        "destinationSource": "Destination source",
+        "destinationName": "Custom destination name",
         "lineName": "Line name",
         "lineColor": "Line color",
         "icon": "Custom transport icon",
         "remove": "Remove"
+      },
+      "destinationSourceOptions": {
+        "direction": "Attribute 'direction'",
+        "head_sign": "Attribute 'head_sign'",
+        "custom": "Custom value"
       },
       "help": {
         "showListHeader": "Show the header row for the departure list",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -48,11 +48,17 @@
       "entity": {
         "entity": "Entidad",
         "stationName": "Nombre de la estación",
-        "destinationName": "Nombre del destino",
+        "destinationSource": "Fuente del nombre de destino",
+        "destinationName": "Nombre de destino personalizado",
         "lineName": "Nombre de línea",
         "lineColor": "Color de línea",
         "icon": "Icono de transporte personalizado",
         "remove": "Eliminar"
+      },
+      "destinationSourceOptions": {
+        "direction": "Atributo 'direction'",
+        "head_sign": "Atributo 'head_sign'",
+        "custom": "Valor personalizado"
       },
       "help": {
         "showListHeader": "Muestra los encabezados de columna de la lista de salidas",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -48,11 +48,17 @@
       "entity": {
         "entity": "Entité",
         "stationName": "Nom de la station",
-        "destinationName": "Nom de la destination",
+        "destinationSource": "Source du nom de destination",
+        "destinationName": "Nom de destination personnalisé",
         "lineName": "Nom de la ligne",
         "lineColor": "Couleur de la ligne",
         "icon": "Icône de transport personnalisée",
         "remove": "Supprimer"
+      },
+      "destinationSourceOptions": {
+        "direction": "Attribut 'direction'",
+        "head_sign": "Attribut 'head_sign'",
+        "custom": "Valeur personnalisée"
       },
       "help": {
         "showListHeader": "Affiche les en-têtes de colonnes de la liste des départs",

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -48,11 +48,17 @@
       "entity": {
         "entity": "Entītija",
         "stationName": "Stacijas nosaukums",
-        "destinationName": "Galamērķa nosaukums",
+        "destinationSource": "Galamērķa nosaukuma avots",
+        "destinationName": "Pielāgots galamērķa nosaukums",
         "lineName": "Līnijas nosaukums",
         "lineColor": "Līnijas krāsa",
         "icon": "Pielāgota transporta ikona",
         "remove": "Noņemt"
+      },
+      "destinationSourceOptions": {
+        "direction": "Atribūts 'direction'",
+        "head_sign": "Atribūts 'head_sign'",
+        "custom": "Pielāgota vērtība"
       },
       "help": {
         "showListHeader": "Rāda atiešanu saraksta kolonnu virsrakstus",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -48,11 +48,17 @@
       "entity": {
         "entity": "Encja",
         "stationName": "Nazwa stacji",
-        "destinationName": "Nazwa celu",
+        "destinationSource": "Źródło nazwy celu",
+        "destinationName": "Niestandardowa nazwa celu",
         "lineName": "Nazwa linii",
         "lineColor": "Kolor linii",
         "icon": "Własna ikona transportu",
         "remove": "Usuń"
+      },
+      "destinationSourceOptions": {
+        "direction": "Atrybut 'direction'",
+        "head_sign": "Atrybut 'head_sign'",
+        "custom": "Wartość niestandardowa"
       },
       "help": {
         "showListHeader": "Wyświetla nagłówki kolumn listy odjazdów",

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,9 +31,16 @@ export interface Config extends LovelaceCardConfig {
   title: string;
 }
 
+export enum DestinationSource {
+  DIRECTION = "direction",
+  HEAD_SIGN = "head_sign",
+  CUSTOM = "custom",
+}
+
 // An entity configuration within the card configuration
 export interface EntityConfig {
   destinationName: string | null;
+  destinationSource?: DestinationSource;
   entity: string;
   icon: string | null;
   lineColor: string | null;


### PR DESCRIPTION
## Summary

- Adds a new `destinationSource` entity config option with three modes: `direction` (default), `head_sign`, and `custom`
- `head_sign` mode reads the per-trip `head_sign` field from the `times` array, enabling correct destination display when trains are rerouted during disruptions
- `custom` mode uses the manually set `destinationName` value (previously the only override option)
- Adds `DestinationSource` enum to `types.ts` and wires it through `data-pool.ts`, `content.ts`, and the entity editor
- Updates all 7 locales and README with full documentation of the new option

## Test plan

- [x] Configure an entity with `destinationSource: direction` — destination shows the sensor's `direction` attribute (existing behaviour)
- [x] Configure an entity with `destinationSource: head_sign` — each departure row shows the individual trip's `head_sign` value
- [x] Configure an entity with `destinationSource: custom` and a `destinationName` — custom name is shown for all rows
- [x] Verify the dropdown appears correctly in the visual editor for all three options
- [x] Verify that entities without `destinationSource` in their saved config default to `direction` behaviour
- [x] Test in both vertical (list) and horizontal (table) card orientations