### PR TITLE
chore: bump version to 3.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "departures-card",
-  "version": "3.7.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "departures-card",
-      "version": "3.7.0",
+      "version": "3.9.1",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/alex-jung/ha-departures-card",
   "license": "MIT",
   "author": "Alex Jung <jungdevelop@googlemail.com>",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "type": "module",
   "scripts": {
     "start": "rollup -c --watch",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { CardOrientation, CardTheme, LayoutCell } from "./types";
 
-export const CARD_VERSION = "3.9.0";
+export const CARD_VERSION = "3.9.1";
 export const CARD_REPO_URL = "https://github.com/alex-jung/ha-departures-card";
 
 export const DEFAULT_UPDATE_INTERVAL = 10000; // -> 10 sec


### PR DESCRIPTION
## Summary
- Bumps version from 3.9.0 to 3.9.1 (bugfix release)

## Release
After merging, tag `v3.9.1` on master to trigger the release workflow.